### PR TITLE
Added paper, genetic links, to afl++

### DIFF
--- a/data/fuzzers.json
+++ b/data/fuzzers.json
@@ -16,25 +16,32 @@
   },
   {
     "name": "AFL++",
-    "year": 2019,
+    "year": 2020,
     "author": [
-      "Marc Heuse",
-      "Heiko Eißfeldt",
       "Andrea Fioraldi",
-      "Dominik Maier"
+      "Dominik Maier",
+      "Marc Heuse",
+      "Heiko Eißfeldt"
     ],
     "toolurl": "https://github.com/AFLplusplus/AFLplusplus",
     "miscurl": [
-      "https://aflplus.plus/"
+      "https://aflplus.plus/",
+      "https://www.usenix.org/system/files/woot20-paper-fioraldi.pdf"
     ],
     "targets": [
       "File"
     ],
     "references": [
       "AFLFast",
-      "MOPT"
+      "MOPT",
+      "AFL",
+      "Redqueen",
+      "AflSmart"
+
     ],
-    "color": "greybox"
+    "color": "greybox",
+    "title": "AFL++: Combining Incremental Steps of Fuzzing Research",
+    "booktitle": "14th USENIX Workshop on Offensive Technologies (WOOT 20)"
   },
   {
     "name": "AFLFast",


### PR DESCRIPTION
This PR updates the AFL++ with the relevant paper, and adds directly or indirectly incorporated fuzzers (the ones I could think of)