### PR TITLE
Remove whitespace in SymCC toolurl

### DIFF
--- a/data/fuzzers.json
+++ b/data/fuzzers.json
@@ -3245,7 +3245,7 @@
     ],
     "title": "Symbolic execution with SYMCC: Don’t interpret, compile!",
     "booktitle": "Proceedings of the USENIX Security Symposium",
-    "toolurl": "http://www.s3. eurecom.fr/tools/symbolic_execution/symcc.html",
+    "toolurl": "http://www.s3.eurecom.fr/tools/symbolic_execution/symcc.html",
     "miscurl": [
       "http://www.s3.eurecom.fr/docs/usenixsec20_symcc.pdf"
     ],


### PR DESCRIPTION
PR corrected a minor typo in SymCC
The whitespace misleads access to the desired link.(tool url)