### PR TITLE
Fix misspelled "greybox"

### DIFF
--- a/data/fuzzers.json
+++ b/data/fuzzers.json
@@ -777,7 +777,7 @@
     "references": [
       "AFLGo"
     ],
-    "color": "graybox"
+    "color": "greybox"
   },
   {
     "name": "CDFUZZ",
@@ -5082,7 +5082,7 @@
     "targets": [
       "DL inference engine"
     ],
-    "color": "greykbox"
+    "color": "greybox"
   },
   {
     "name": "MALintent",


### PR DESCRIPTION
This didn't affect the rendered graph, as greybox is the default color chosen by asefuzz.js.

Test Plan:

```
$ jq '.[].color' <data/fuzzers.json | sort -u
"blackbox"
"greybox"
"whitebox"
```