### PR TITLE
Fix Uncaptured Zoom and Click Events

### DIFF
--- a/css/asefuzz.css
+++ b/css/asefuzz.css
@@ -4,6 +4,8 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
 }
 
 .main {
@@ -11,6 +13,7 @@ body {
   display: flex;
   margin-left: 0;
   margin-right: 0;
+  min-height: 0;
 }
 
 .searchform {
@@ -41,6 +44,8 @@ body {
 
 .canvas {
   flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .separator {
@@ -48,7 +53,7 @@ body {
 }
 
 .infobox {
-  position: absolute;
+  position: relative;
   width: 100%;
   height: 100%;
   overflow-x: hidden;

--- a/js/asefuzz.js
+++ b/js/asefuzz.js
@@ -660,6 +660,7 @@ d3.json("data/fuzzers.json")
     initStats(d.nodes);
     zoom.scaleTo(canvas, minScale);
     // Center the graph after a sec.
+    hideInfobox();
     setTimeout(function () {
       const key = getQueryVariable("k");
       const data = d.nodes.find(function (d) { return (d.name === key); });


### PR DESCRIPTION
Currently the page does not correctly capture zoom and click events on the graph as an invisible element (infobox) is in the way of it. This PR fixes the issue.